### PR TITLE
Added vs rather filter

### DIFF
--- a/src/components/pagesView/index.js
+++ b/src/components/pagesView/index.js
@@ -21,7 +21,7 @@ const List = ({ pages: { pages } }) => (
 
 
 const Detailed = ({ pages: { pages } , id }) => {
-  let page = pages && pages.filter( item => item.id === parseInt(id, 10))[0]
+  let page = pages && pages.find( item => item.id === parseInt(id, 10))
   return (
     <div className="PageView__Container">
     <h3 dangerouslySetInnerHTML={{ __html: page && page.title.rendered}}></h3>


### PR DESCRIPTION
@elpuas I was thinking and actually `find` is better because it will look for just one item into the array which is what we need on this point.

> The find() method returns the value of the first element in the array that satisfies the provided testing function. Otherwise undefined is returned.